### PR TITLE
Use 'yajl' instead of 'json' to dump a record

### DIFF
--- a/lib/fluent/plugin/out_http.rb
+++ b/lib/fluent/plugin/out_http.rb
@@ -7,6 +7,7 @@ class Fluent::HTTPOutput < Fluent::Output
     super
     require 'net/http'
     require 'uri'
+    require 'yajl'
   end
 
   # Endpoint URL ex. localhost.local/api/
@@ -77,7 +78,7 @@ class Fluent::HTTPOutput < Fluent::Output
   end
 
   def set_json_body(req, data)
-    req.body = JSON.dump(data)
+    req.body = Yajl.dump(data)
     req['Content-Type'] = 'application/json'
   end
 


### PR DESCRIPTION
Fluentd treats the logs as a binay(ASCII-8BIT) by default
because log collector doesn't know application requirements.
In this case, json library should dump such record correctly.
Yajl can do but JSON can't, so we should use 'yajl' instead of 'json'.

This pull request is related to this issue https://github.com/fluent/fluentd/issues/215
