### PR TITLE
Add a link to fluentd.org in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# fluent-plugin-out-http
+# fluent-plugin-out-http, a plugin for [Fluentd](http://fluentd.org)
 
 A generic [fluentd][1] output plugin for sending logs to an HTTP endpoint.
 


### PR DESCRIPTION
I am adding a link to Fluentd.org in your README.md file to put Fluentd in context for newcomers.
