### PR TITLE
Send query_string to endpoint_url

### DIFF
--- a/lib/fluent/plugin/out_http.rb
+++ b/lib/fluent/plugin/out_http.rb
@@ -86,7 +86,7 @@ class Fluent::HTTPOutput < Fluent::Output
   def create_request(tag, time, record)
     url = format_url(tag, time, record)
     uri = URI.parse(url)
-    req = Net::HTTP.const_get(@http_method.to_s.capitalize).new(uri.path)
+    req = Net::HTTP.const_get(@http_method.to_s.capitalize).new(uri.request_uri)
     set_body(req, tag, time, record)
     set_header(req, tag, time, record)
     return req, uri


### PR DESCRIPTION
If set endpoint_url to `http://example.com/api?foo=bar`, current out-http does not send `foo=bar`.
I want to send not only path but also query_string to endpoint server.
