### PR TITLE
Add support for https proxy via ENV variables

### DIFF
--- a/lib/fluent/plugin/out_http.rb
+++ b/lib/fluent/plugin/out_http.rb
@@ -111,6 +111,10 @@ class Fluent::HTTPOutput < Fluent::Output
       opts
   end
 
+  def proxies
+    ENV['HTTPS_PROXY'] || ENV['HTTP_PROXY'] || ENV['http_proxy'] || ENV['https_proxy']
+  end
+
   def send_request(req, uri)
     is_rate_limited = (@rate_limit_msec != 0 and not @last_request_time.nil?)
     if is_rate_limited and ((Time.now.to_f - @last_request_time) * 1000.0 < @rate_limit_msec)
@@ -126,8 +130,7 @@ class Fluent::HTTPOutput < Fluent::Output
       end
       @last_request_time = Time.now.to_f
 
-      if ENV['HTTPS_PROXY'] || ENV['HTTP_PROXY'] || ENV['http_proxy'] || ENV['https_proxy']
-        proxy = ENV['HTTPS_PROXY'] || ENV['https_proxy'] || ENV['HTTP_PROXY'] || ENV['http_proxy']
+      if proxy = proxies
         proxy_uri = URI.parse(proxy)
 
         res = Net::HTTP.start(uri.host, uri.port,


### PR DESCRIPTION
This PR adds support for HTTP(s) proxy. If any of the env variables `HTTPS_PROXY`, `HTTP_PROXY`, `http_proxy`, `https_proxy` is set, this will be used for proxying http(s) calls.

While by default Ruby would try to use `http_proxy` variable if set, it does not work for https endpoints. This PR makes it explicit and if any of the above variables is set, it will be used both for http and https endpoints.