### PR TITLE
Added plain text transport capability & specify cacert file for ssl verify

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ A generic [fluentd][1] output plugin for sending logs to an HTTP endpoint.
       authentication  basic  # default: none
       username        alice  # default: ''
       password        bobpop # default: '', secret: true
+      cacert_file     /etc/ssl/endpoint1.cert # default: ''
     </match>
 
 ## Usage notes

--- a/lib/fluent/plugin/out_http.rb
+++ b/lib/fluent/plugin/out_http.rb
@@ -27,6 +27,9 @@ class Fluent::HTTPOutput < Fluent::Output
   # Raise errors that were rescued during HTTP requests?
   config_param :raise_on_error, :bool, :default => true
 
+  # ca file to use for https request
+  config_param :cacert_file, :string, :default => ''
+
   # nil | 'none' | 'basic'
   config_param :authentication, :string, :default => nil
   config_param :username, :string, :default => ''
@@ -40,6 +43,8 @@ class Fluent::HTTPOutput < Fluent::Output
                        else
                          OpenSSL::SSL::VERIFY_PEER
                        end
+
+    @ca_file = @cacert_file
 
     serializers = [:json, :form, :text]
     @serializer = if serializers.include? @serializer.intern
@@ -71,7 +76,7 @@ class Fluent::HTTPOutput < Fluent::Output
   def shutdown
     super
   end
-
+  
   def format_url(tag, time, record)
     @endpoint_url
   end
@@ -115,6 +120,7 @@ class Fluent::HTTPOutput < Fluent::Output
         :use_ssl => uri.scheme == 'https'
       }
       opts[:verify_mode] = @ssl_verify_mode if opts[:use_ssl]
+      opts[:ca_file] = File.join(@ca_file) if File.file?(@ca_file)
       opts
   end
 

--- a/lib/fluent/plugin/out_http.rb
+++ b/lib/fluent/plugin/out_http.rb
@@ -41,7 +41,7 @@ class Fluent::HTTPOutput < Fluent::Output
                          OpenSSL::SSL::VERIFY_PEER
                        end
 
-    serializers = [:json, :form]
+    serializers = [:json, :form, :text]
     @serializer = if serializers.include? @serializer.intern
                     @serializer.intern
                   else
@@ -79,6 +79,8 @@ class Fluent::HTTPOutput < Fluent::Output
   def set_body(req, tag, time, record)
     if @serializer == :json
       set_json_body(req, record)
+    elsif @serializer == :text
+      set_text_body(req, record)
     else
       req.set_form_data(record)
     end
@@ -92,6 +94,11 @@ class Fluent::HTTPOutput < Fluent::Output
   def set_json_body(req, data)
     req.body = Yajl.dump(data)
     req['Content-Type'] = 'application/json'
+  end
+
+  def set_text_body(req, data)
+    req.body = data["message"]
+    req['Content-Type'] = 'text/plain'
   end
 
   def create_request(tag, time, record)


### PR DESCRIPTION
Capability allows the plugin to pass through raw plain text content as HTTP body without any parsing or transformation issues. 