### PR TITLE
Add :raw serializer

### DIFF
--- a/lib/fluent/plugin/out_http.rb
+++ b/lib/fluent/plugin/out_http.rb
@@ -24,8 +24,8 @@ class Fluent::Plugin::HTTPOutput < Fluent::Plugin::Output
   # HTTP method
   config_param :http_method, :enum, list: [:get, :put, :post, :delete], :default => :post
 
-  # form | json
-  config_param :serializer, :enum, list: [:json, :form, :text], :default => :form
+  # form | json | text | raw
+  config_param :serializer, :enum, list: [:json, :form, :text, :raw], :default => :form
 
   # Simple rate limiting: ignore any records within `rate_limit_msec`
   # since the last one.
@@ -93,6 +93,8 @@ class Fluent::Plugin::HTTPOutput < Fluent::Plugin::Output
       set_json_body(req, record)
     elsif @serializer == :text
       set_text_body(req, record)
+    elsif @serializer == :raw
+      set_raw_body(req, record)
     else
       req.set_form_data(record)
     end
@@ -118,6 +120,10 @@ class Fluent::Plugin::HTTPOutput < Fluent::Plugin::Output
   def set_text_body(req, data)
     req.body = data["message"]
     req['Content-Type'] = 'text/plain'
+  end
+
+  def set_raw_body(req, data)
+    req.body = data
   end
 
   def create_request(tag, time, record)

--- a/lib/fluent/plugin/out_http.rb
+++ b/lib/fluent/plugin/out_http.rb
@@ -123,7 +123,8 @@ class Fluent::Plugin::HTTPOutput < Fluent::Plugin::Output
   end
 
   def set_raw_body(req, data)
-    req.body = data
+    req.body = data.to_s
+    req['Content-Type'] = 'application/octet-stream'
   end
 
   def create_request(tag, time, record)


### PR DESCRIPTION
To facilitate the use of custom formatters which already serialize their output.

With the addition of custom formatters in #38, we need a way to pass their output as-is as the body of the HTTP request as the formatters serialize their output (e.g. msgpack, csv, json, etc.).