### PR TITLE
Pass chunk directly instead of chunk.metadata

### DIFF
--- a/lib/fluent/plugin/out_http.rb
+++ b/lib/fluent/plugin/out_http.rb
@@ -226,7 +226,7 @@ class Fluent::Plugin::HTTPOutput < Fluent::Plugin::Output
 
   def write(chunk)
     tag = chunk.metadata.tag
-    @endpoint_url = extract_placeholders(@endpoint_url, chunk.metadata)
+    @endpoint_url = extract_placeholders(@endpoint_url, chunk)
     chunk.msgpack_each do |time, record|
       handle_record(tag, time, record)
     end


### PR DESCRIPTION
extract_placeholders should be passed `chunk` instance directly instead of `chunk.metadata`.