### PR TITLE
Support all private key types

### DIFF
--- a/lib/fluent/plugin/out_http.rb
+++ b/lib/fluent/plugin/out_http.rb
@@ -153,7 +153,7 @@ class Fluent::Plugin::HTTPOutput < Fluent::Plugin::Output
       opts[:verify_mode] = @ssl_verify_mode if opts[:use_ssl]
       opts[:ca_file] = File.join(@ca_file) if File.file?(@ca_file)
       opts[:cert] = OpenSSL::X509::Certificate.new(File.read(@client_cert_path)) if File.file?(@client_cert_path)
-      opts[:key] = OpenSSL::PKey::RSA.new(File.read(@private_key_path), @private_key_passphrase) if File.file?(@private_key_path)
+      opts[:key] = OpenSSL::PKey.read(File.read(@private_key_path), @private_key_passphrase) if File.file?(@private_key_path)
       opts
   end
 


### PR DESCRIPTION
Because OpenSSL::PKey::RSA.new only supports RSA private key.
We should use OpenSSL::PKey.read intead.

ref: https://ruby-doc.org/stdlib-2.5.0/libdoc/openssl/rdoc/OpenSSL/PKey.html#method-c-read