### PR TITLE
Mimic the debug log behavior of the standard library out_http plugin

### DIFF
--- a/lib/fluent/plugin/out_http.rb
+++ b/lib/fluent/plugin/out_http.rb
@@ -302,6 +302,9 @@ class Fluent::Plugin::HTTPOutput < Fluent::Plugin::Output
   def write(chunk)
     tag = chunk.metadata.tag
     @endpoint_url = extract_placeholders(@endpoint_url, chunk)
+
+    log.debug { "#{@http_method.capitalize} data to #{@endpoint_url} with chunk(#{dump_unique_id_hex(chunk.unique_id)})" }
+
     if @bulk_request
       time = Fluent::Engine.now
       handle_records(tag, time, chunk)


### PR DESCRIPTION
In a system that disables the @type stdout output, debug logging will help developers debug problems with their configuration.

I took a stab at trying to find a good way to test this, but didn't have much luck. I'm guessing there are some existing patterns for testing logging. 