### PR TITLE
Avoid unnecessary gzip decompression and recompression

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Install
         run: |
           rake install
-          gem install test-unit webrick
+          gem install test-unit test-unit-rr webrick
       - name: Test
         run: |
           mkdir -p tmp

--- a/fluent-plugin-out-http.gemspec
+++ b/fluent-plugin-out-http.gemspec
@@ -22,5 +22,6 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "bundler"
   gem.add_development_dependency "rake"
   gem.add_development_dependency "test-unit", ">= 3.1.0"
+  gem.add_development_dependency "test-unit-rr", "~> 1.0"
   gem.add_development_dependency "webrick"
 end

--- a/lib/fluent/plugin/out_http.rb
+++ b/lib/fluent/plugin/out_http.rb
@@ -146,12 +146,21 @@ class Fluent::Plugin::HTTPOutput < Fluent::Plugin::Output
     end
   end
 
+  def buffer_compressed?
+    @buffered && @buffer.compress == :gzip
+  end
+
   def compress_body(req, data)
     return unless @compress_request
-    gz = Zlib::GzipWriter.new(StringIO.new)
-    gz << data
 
     req['Content-Encoding'] = "gzip"
+    if buffer_compressed?
+      req.body = data
+      return
+    end
+
+    gz = Zlib::GzipWriter.new(StringIO.new)
+    gz << data
     req.body = gz.close.string
   end
 
@@ -261,7 +270,8 @@ class Fluent::Plugin::HTTPOutput < Fluent::Plugin::Output
   end
 
   def handle_records(tag, time, chunk)
-    req, uri = create_request(tag, time, chunk.read)
+    record = buffer_compressed? ? chunk.read(compressed: @buffer.compress) : chunk.read
+    req, uri = create_request(tag, time, record)
     send_request(req, uri)
   end
 

--- a/test/plugin/test_out_http.rb
+++ b/test/plugin/test_out_http.rb
@@ -8,6 +8,8 @@ require 'fluent/test/driver/output'
 require 'fluent/test/helpers'
 require_relative "./script/plugin/formatter_test"
 
+require 'test/unit/rr'
+
 module OS
   # ref. http://stackoverflow.com/questions/170956/how-can-i-find-which-operating-system-my-ruby-program-is-running-on
   def OS.windows?
@@ -100,9 +102,18 @@ class HTTPOutputTestBase < Test::Unit::TestCase
 
           expander = -> (req) {
             if req["Content-Encoding"] == "gzip"
-              StringIO.open(req.body, 'rb'){|sio|
-                Zlib::GzipReader.wrap(sio).read
-              }
+              sio = StringIO.new(req.body)
+              output = ""
+
+              until sio.eof?
+                gz = Zlib::GzipReader.new(sio)
+                output << gz.read
+                unused = gz.unused
+                if unused
+                  sio.pos -= unused.length
+                end
+              end
+              output
             else
               req.body
             end
@@ -495,6 +506,50 @@ class HTTPOutputTest < HTTPOutputTestBase
     def test_emit_x_ndjson_with_compression
       binary_string = "\xe3\x81\x82"
       d = create_driver CONFIG_JSON + %[buffered true\nbulk_request true\ncompress_request true]
+      d.run(default_tag: 'test.metrics') do
+        d.feed({ 'field1' => 50, 'field2' => 20, 'field3' => 10, 'otherfield' => 1, 'binary' => binary_string })
+        d.feed({ 'field1' => 70, 'field2' => 30, 'field3' => 20, 'otherfield' => 2, 'binary' => binary_string })
+      end
+
+      assert_equal 1, @posts.size
+      record = @posts[0]
+
+      expected =[
+        {
+          "binary"     => "\u3042",
+          "field1"     => 50,
+          "field2"     => 20,
+          "field3"     => 10,
+          "otherfield" => 1
+        },
+        {
+          "binary"     => "\u3042",
+          "field1"     => 70,
+          "field2"     => 30,
+          "field3"     => 20,
+          "otherfield" => 2
+        }
+      ]
+
+      assert_equal expected, record[:x_ndjson]
+      assert_nil record[:auth]
+    end
+
+    def test_emit_x_ndjson_with_compression_with_compressed_buffer
+      binary_string = "\xe3\x81\x82"
+      d = create_driver CONFIG_JSON + %[
+        buffered true
+        bulk_request true
+        compress_request true
+        <buffer>
+          @type memory
+          compress gzip
+        </buffer>
+      ]
+
+      # Should not recompress
+      dont_allow(Zlib::GzipWriter).new
+
       d.run(default_tag: 'test.metrics') do
         d.feed({ 'field1' => 50, 'field2' => 20, 'field3' => 10, 'otherfield' => 1, 'binary' => binary_string })
         d.feed({ 'field1' => 70, 'field2' => 30, 'field3' => 20, 'otherfield' => 2, 'binary' => binary_string })


### PR DESCRIPTION
Resolves #72

Currently, when `compress_request true` is enabled in `out_http` and the buffer is configured with `compress gzip`, Fluentd automatically decompresses the buffer chunk before passing it to the plugin. The plugin then unnecessarily recompresses the payload using `Zlib::GzipWriter`. 
This causes redundant CPU overhead.

This has same approach with https://github.com/fluent/fluent-plugin-s3/pull/460