### PR TITLE
Replace yajl-ruby with the json gem for JSON handling

### DIFF
--- a/fluent-plugin-out-http.gemspec
+++ b/fluent-plugin-out-http.gemspec
@@ -17,7 +17,6 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version  = '>= 2.1.0'
 
-  gem.add_runtime_dependency "yajl-ruby", "~> 1.0"
   gem.add_runtime_dependency "fluentd", [">= 0.14.22", "< 2"]
   gem.add_development_dependency "bundler"
   gem.add_development_dependency "rake"

--- a/lib/fluent/plugin/out_http.rb
+++ b/lib/fluent/plugin/out_http.rb
@@ -1,6 +1,5 @@
 require 'net/http'
 require 'uri'
-require 'yajl'
 require 'fluent/plugin/output'
 require 'tempfile'
 require 'openssl'
@@ -165,7 +164,7 @@ class Fluent::Plugin::HTTPOutput < Fluent::Plugin::Output
   end
 
   def set_json_body(req, data)
-    req.body = Yajl.dump(data)
+    req.body = JSON.generate(data)
     req['Content-Type'] = 'application/json'
     compress_body(req, req.body)
   end

--- a/test/plugin/test_out_http.rb
+++ b/test/plugin/test_out_http.rb
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 require 'net/http'
 require 'uri'
-require 'yajl'
 require 'fluent/test/http_output_test'
 require 'fluent/plugin/out_http'
 require 'fluent/test/driver/output'
@@ -121,7 +120,7 @@ class HTTPOutputTestBase < Test::Unit::TestCase
 
           record = {:auth => nil}
           if req.content_type == 'application/json'
-            record[:json] = Yajl.load(expander.call(req))
+            record[:json] = JSON.parse(expander.call(req))
           elsif req.content_type == 'text/plain'
             puts req
             record[:data] = expander.call(req)
@@ -130,7 +129,7 @@ class HTTPOutputTestBase < Test::Unit::TestCase
           elsif req.content_type == 'application/x-ndjson'
             data = []
             expander.call(req).each_line { |l|
-              data << Yajl.load(l)
+              data << JSON.parse(l)
             }
             record[:x_ndjson] = data
           else


### PR DESCRIPTION
Since the yajl-ruby gem depends on a deprecated Ruby C API, it cannot be installed with Ruby 4.1.